### PR TITLE
Support for logistic growth

### DIFF
--- a/multi_prophet/__init__.py
+++ b/multi_prophet/__init__.py
@@ -61,7 +61,11 @@ class MultiProphet:
         return list(self.model_pool.values())[0]
 
     def _create_dataframe(self, df, column):
-        return pd.DataFrame({
+        train_df = pd.DataFrame({
           "ds": df[TIME_COLUMN].values,
           "y": df[column].values
         })
+        train_df["cap"] = df[f"cap_{column}"].values
+        train_df["floor"] = df[f"floor_{column}"].values
+
+        return train_df

--- a/multi_prophet/__init__.py
+++ b/multi_prophet/__init__.py
@@ -65,7 +65,14 @@ class MultiProphet:
           "ds": df[TIME_COLUMN].values,
           "y": df[column].values
         })
-        train_df["cap"] = df[f"cap_{column}"].values
-        train_df["floor"] = df[f"floor_{column}"].values
+
+        if self._contains_columns(df, f"cap_{column}"):
+            train_df["cap"] = df[f"cap_{column}"].values
+
+        if self._contains_columns(df, f"floor_{column}"):
+            train_df["floor"] = df[f"floor_{column}"].values
 
         return train_df
+
+    def _contains_columns(self, df, column):
+        return column in df.columns

--- a/tests/test_prophet.py
+++ b/tests/test_prophet.py
@@ -30,6 +30,14 @@ class ProphetTestCase(unittest.TestCase):
         # will be tested later by checking the performance of the model
         self.assertTrue(True)
 
+    def test_fit_logistic(self):
+        mp = multi_prophet.Prophet(growth="logistic")
+        self.df["cap"] = 200
+        self.df["floor"] = 0
+        mp.fit(self.df)
+        # will be tested later by checking the performance of the model
+        self.assertTrue(True)
+
     def test_fit_kwargs(self):
         mp = multi_prophet.Prophet()
         mp.fit(self.df, algorithm="Newton")


### PR DESCRIPTION
Creates `cap` and `floor` columns in training df if provided.
`cap` is mandatory for `logistic` growth.